### PR TITLE
Fix pandas deprecation warnings

### DIFF
--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -267,8 +267,8 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
     # -- If only_last was set by the user,
     # create subset of the data that represent the most recent day
     if only_last:
-        start_date = df.timestamp.iget(-1) - datetime.timedelta(days=7)
-        start_anoms = df.timestamp.iget(-1) - datetime.timedelta(days=1)
+        start_date = df.timestamp.iloc[-1] - datetime.timedelta(days=7)
+        start_anoms = df.timestamp.iloc[-1] - datetime.timedelta(days=1)
         if gran is "day":
             breaks = 3 * 12
             num_days_per_line = 7
@@ -292,7 +292,7 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
                            & (df.timestamp > start_date)]
         if len(all_anoms) > 0:
             all_anoms = all_anoms[all_anoms.timestamp >=
-                                  x_subset_single_day.timestamp.iget(0)]
+                                  x_subset_single_day.timestamp.iloc[0]]
         num_obs = len(x_subset_single_day.value)
 
     # Calculate number of anomalies as a percentage

--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -176,15 +176,15 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
             num_obs_in_period = period * 7 * piecewise_median_period_weeks
             num_days_in_period = 7 * piecewise_median_period_weeks
 
-        last_date = df.timestamp.iget(-1)
+        last_date = df.timestamp.iloc[-1]
 
         all_data = []
 
         for j in range(0, len(df.timestamp), num_obs_in_period):
-            start_date = df.timestamp.iget(j)
+            start_date = df.timestamp.iloc[j]
             end_date = min(start_date
                            + datetime.timedelta(days=num_obs_in_period),
-                           df.timestamp.iget(-1))
+                           df.timestamp.iloc[-1])
 
             # if there is at least 14 days left, subset it,
             # otherwise subset last_date - 14days
@@ -276,11 +276,11 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
             if only_last == 'day':
                 breaks = 12
             else:
-                start_date = df.timestamp.iget(-1) - datetime.timedelta(days=2)
+                start_date = df.timestamp.iloc[-1] - datetime.timedelta(days=2)
                 # truncate to days
                 start_date = datetime.date(start_date.year,
                                            start_date.month, start_date.day)
-                start_anoms = (df.timestamp.iget(-1)
+                start_anoms = (df.timestamp.iloc[-1]
                                - datetime.timedelta(hours=1))
                 breaks = 3
 


### PR DESCRIPTION
/usr/local/lib/python2.7/site-packages/pyculiarity/detect_ts.py:270: FutureWarning: iget(i) is deprecated. Please use .iloc[i] or .iat[i]
  start_date = df.timestamp.iget(-1) - datetime.timedelta(days=7)
/usr/local/lib/python2.7/site-packages/pyculiarity/detect_ts.py:271: FutureWarning: iget(i) is deprecated. Please use .iloc[i] or .iat[i]
  start_anoms = df.timestamp.iget(-1) - datetime.timedelta(days=1)
/usr/local/lib/python2.7/site-packages/pyculiarity/detect_ts.py:295: FutureWarning: iget(i) is deprecated. Please use .iloc[i] or .iat[i]
  x_subset_single_day.timestamp.iget(0)]