### PR TITLE
set drop_duplicates function to work inplace

### DIFF
--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -258,11 +258,11 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
 
     # Cleanup potential duplicates
     try:
-        all_anoms.drop_duplicates(subset=['timestamp'])
-        seasonal_plus_trend.drop_duplicates(subset=['timestamp'])
+        all_anoms.drop_duplicates(subset=['timestamp'], inplace=True)
+        seasonal_plus_trend.drop_duplicates(subset=['timestamp'], inplace=True)
     except TypeError:
-        all_anoms.drop_duplicates(cols=['timestamp'])
-        seasonal_plus_trend.drop_duplicates(cols=['timestamp'])
+        all_anoms.drop_duplicates(cols=['timestamp'], inplace=True)
+        seasonal_plus_trend.drop_duplicates(cols=['timestamp'], inplace=True)
 
     # -- If only_last was set by the user,
     # create subset of the data that represent the most recent day


### PR DESCRIPTION
Using detect_ts in python3, I ran into a problem where duplicates were not being dropped in seasonal_plus_trend.  This led to an error when forming the output dataframe, `anoms`.  Adding `inplace=True` to the `drop_duplicates` calls seems to fix the problem.