### PR TITLE
Fix pandas.lib future warning

### DIFF
--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -4,7 +4,7 @@ from date_utils import format_timestamp, get_gran, date_format, datetimes_from_t
 from detect_anoms import detect_anoms
 from math import ceil
 from pandas import DataFrame
-from pandas.lib import Timestamp
+from pandas._libs.lib import Timestamp
 import datetime
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyculiarity',
-    version='0.0.2',
+    version='0.0.6',
     description='A Python port of Twitter\'s AnomalyDetection R Package.',
     long_description=__doc__,
     url='https://github.com/nicolasmiller/pyculiarity',


### PR DESCRIPTION
pandas.lib module is deprecated and will be removed in a future version.
These are private functions and can be accessed from pandas._libs.lib
instead of from pandas.lib import Timestamp

please apply this is stable tag as well