### PR TITLE
strptime() argument 1 must be str, not Timestamp

### DIFF
--- a/pyculiarity/date_utils.py
+++ b/pyculiarity/date_utils.py
@@ -18,8 +18,7 @@ def format_timestamp(indf, index=0):
 
     column = indf.iloc[:,index]
 
-    if match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\+\\d{4}$",
-             column[0]):
+    if match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\+\\d{4}$",str(column[0])):
         column = date_format(column, "%Y-%m-%d %H:%M:%S")
     elif match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$", str(column[0])):
         column = date_format(column, "%Y-%m-%d %H:%M:%S")

--- a/pyculiarity/date_utils.py
+++ b/pyculiarity/date_utils.py
@@ -21,17 +21,17 @@ def format_timestamp(indf, index=0):
     if match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\+\\d{4}$",
              column[0]):
         column = date_format(column, "%Y-%m-%d %H:%M:%S")
-    elif match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$", column[0]):
+    elif match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$", str(column[0])):
         column = date_format(column, "%Y-%m-%d %H:%M:%S")
-    elif match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}$", column[0]):
+    elif match("^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}$", str(column[0])):
         column = date_format(column, "%Y-%m-%d %H:%M")
-    elif match("^\\d{2}/\\d{2}/\\d{2}$", column[0]):
+    elif match("^\\d{2}/\\d{2}/\\d{2}$", str(column[0])):
         column = date_format(column, "%m/%d/%y")
-    elif match("^\\d{2}/\\d{2}/\\d{4}$", column[0]):
+    elif match("^\\d{2}/\\d{2}/\\d{4}$", str(column[0])):
         column = date_format(column, "%Y%m%d")
-    elif match("^\\d{4}\\d{2}\\d{2}$", column[0]):
+    elif match("^\\d{4}\\d{2}\\d{2}$", str(column[0])):
         column = date_format(column, "%Y/%m/%d/%H")
-    elif match("^\\d{10}$", column[0]):
+    elif match("^\\d{10}$", str(column[0])):
         column = datetimes_from_ts(column)
 
     indf.iloc[:,index] = column

--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -149,6 +149,8 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
         num_days_per_line = 1
 
     if gran == 'sec':
+    	# Convert the timestamp column into string format
+    	df.timestamp = df.timestamp.dt.strftime("%Y-%m-%d %H:%M:00")
         df.timestamp = date_format(df.timestamp, "%Y-%m-%d %H:%M:00")
         df = format_timestamp(df.groupby('timestamp').aggregate(np.sum))
 

--- a/pyculiarity/detect_ts.py
+++ b/pyculiarity/detect_ts.py
@@ -150,7 +150,7 @@ def detect_ts(df, max_anoms=0.10, direction='pos',
 
     if gran == 'sec':
     	# Convert the timestamp column into string format
-    	df.timestamp = df.timestamp.dt.strftime("%Y-%m-%d %H:%M:00")
+        df.timestamp = df.timestamp.dt.strftime("%Y-%m-%d %H:%M:00")
         df.timestamp = date_format(df.timestamp, "%Y-%m-%d %H:%M:00")
         df = format_timestamp(df.groupby('timestamp').aggregate(np.sum))
 


### PR DESCRIPTION
When the granularity is less than a minute, there is "TypeError: strptime() argument 1 must be str, not Timestamp" on line 152 in detect_ts.py. after converting the timestamp to string format, there is another "TypeError: cannot use a string pattern on a bytes-like object" on line 22 in date_util.py. Above issues have been fixed in this pull request. Please check and merge.